### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": ["logging", "sysadmin", "tools", "winston", "syslog"],
   "dependencies": {
-    "strong-fork-syslog": "1.1.x",
+    "strong-fork-syslog": "1.2.3",
     "lodash": "2.4.x"
   },
   "devDependencies": {


### PR DESCRIPTION
fixing strong-fork-syslog version which is compatible with node 0.12.x
